### PR TITLE
Fix logging logic in rabbitmq collectd plugin

### DIFF
--- a/rabbitmq.py
+++ b/rabbitmq.py
@@ -33,14 +33,14 @@ VERBOSE = True
 # Get all statistics with rabbitmqctl
 def get_rabbitmqctl_status():
     stats = {}
-    
+
     url_overview = 'http://%s:%s/api/overview' %(HOST, PORT)
     passman = urllib2.HTTPPasswordMgrWithDefaultRealm()
     passman.add_password(None, url_overview, USER, PASS)
     authhandler = urllib2.HTTPBasicAuthHandler(passman)
     opener = urllib2.build_opener(authhandler)
     urllib2.install_opener(opener)
-    overview = json.load(urllib2.urlopen(url_overview)) 
+    overview = json.load(urllib2.urlopen(url_overview))
 
     url_nodes = 'http://%s:%s/api/nodes' %(HOST, PORT)
     passman = urllib2.HTTPPasswordMgrWithDefaultRealm()
@@ -102,7 +102,7 @@ def configure_callback(conf):
 def read_callback():
     log('verb', 'read_callback Running')
     info = get_rabbitmqctl_status()
-    
+
     # Send keys to collectd
     for key in info:
         log('verb', 'Sent value: %s %i' %(key, info[key]))
@@ -111,15 +111,16 @@ def read_callback():
         value.type_instance = key
         value.values = [int(info[key])]
         value.dispatch()
-    
+
 # Log messages to collect logger
 def log(t, message):
     if t == 'err':
         collectd.error('%s: %s' %(NAME, message))
     elif t == 'warn':
         collectd.warning('%s: %s' %(NAME, message))
-    elif t == 'verb' and VERBOSE == True:
-        collectd.info('%s: %s' %(NAME, message))
+    elif t == 'verb':
+        if VERBOSE == True:
+            collectd.info('%s: %s' %(NAME, message))
     else:
         collectd.info('%s: %s' %(NAME, message))
 


### PR DESCRIPTION
The logic should be:
- If the log level is verb AND verbose==True, then log
- If the log level is verb AND verbose!=True, then don't log

What was actually happening was:
- If the log level is verb AND verbose==True, then log
- If the log level is verb AND verbose!=True, then doesn't
  match the `elif` condition
  - At which point it falls through to the `else` condition,
    which logs. :crying_cat_face: 

So by nesting two if conditions, we match all things that are
tagged as 'verb' in the outer `elif` condition, but only log
them if verbose==True.
