### PR TITLE
Cast port to integer

### DIFF
--- a/rabbitmq.py
+++ b/rabbitmq.py
@@ -89,7 +89,7 @@ def configure_callback(conf):
         elif node.key == 'Host':
             HOST = node.values[0]
         elif node.key == 'Port':
-            PORT = node.values[0]
+            PORT = int(node.values[0])
         elif node.key == 'User':
             USER = node.values[0]
         elif node.key == 'Pass':


### PR DESCRIPTION
I had an issue running this on Ubuntu 14.04 with collectd 5.5.1.85.g2cf1055-1~trusty and Python 2.7.6 with the following error in syslog:

```
rabbitmq collectd[30270]: Unhandled python exception in read callback: InvalidURL: nonnumeric port: '15672.0'
```
